### PR TITLE
_.bindAll fixes for underscore 1.5.x

### DIFF
--- a/lib/backbone.computedfields.js
+++ b/lib/backbone.computedfields.js
@@ -15,7 +15,7 @@ Backbone.ComputedFields = (function(Backbone, _){
 
     _.extend(ComputedFields.prototype, {
         initialize: function () {
-            _.bindAll(this);
+            _.bindAll.apply(_, [this].concat(_.functions(this)));
 
             this._lookUpComputedFields();
             this._bindModelEvents();


### PR DESCRIPTION
This is a quick fix for _.bindAll, which replicates its old functionality.  You'll probably want to actually whitelist what methods you want - but this was a 5 second fix  for #11 
