### PR TITLE
pass toJSON options and add option to included computed fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,13 @@ computed: {
 }
 ```
 
+If you'd like to force the computed fields into the JSON payload even if the `toJSON` option is `false`, pass 
+`computedFields: true` to the `toJSON` function:
+
+```js
+model.toJSON({ computedFields: true })
+```
+
 ##More details
 
 Up-to-date and complete documentation is located at [/test/spec/backbone.computedfields.spec.js](https://github.com/alexanderbeletsky/backbone.computedfields/blob/master/test/spec/backbone.computedfields.spec.js).

--- a/src/backbone.computedfields.js
+++ b/src/backbone.computedfields.js
@@ -98,9 +98,11 @@ Backbone.ComputedFields = (function(Backbone, _){
         },
 
         _toJSON: function (toJSON) {
-            var attributes = toJSON.call(this.model);
+            var args = Array.prototype.slice.call(arguments, 1),
+                attributes = toJSON.apply(this.model, args),
+                strip = !!(args[0] || {}).computedFields;
 
-            var stripped = _.reduce(this._computedFields, function (memo, computed) {
+            var stripped = strip ? {} : _.reduce(this._computedFields, function (memo, computed) {
                 if (computed.field.toJSON === false) {
                     memo.push(computed.name);
                 }

--- a/test/spec/backbone.computedfields.spec.js
+++ b/test/spec/backbone.computedfields.spec.js
@@ -397,11 +397,49 @@ describe('Backbone.ComputedFields spec', function() {
                 });
 
                 model = new Model({ netPrice: 100, vatRate: 20});
+
                 json = model.toJSON();
             });
 
             it ('should computed field stripped out of JSON', function () {
                 expect(json.grossPrice).to.not.be.ok;
+            });
+
+        });
+
+        describe('when computed is overriden by computedFields option', function () {
+
+            beforeEach(function () {
+                var Model = Backbone.Model.extend({
+                    defaults: {
+                        'netPrice': 0.0,
+                        'vatRate': 0.0
+                    },
+
+                    initialize: function () {
+                        this.computedFields = new Backbone.ComputedFields(this);
+                    },
+
+                    computed: {
+                        grossPrice: {
+                            depends: ['netPrice', 'vatRate'],
+                            get: function (fields) {
+                                return fields.netPrice * (1 + fields.vatRate / 100);
+                            },
+                            set: function (value, fields) {
+                                fields.netPrice = value / (1 + fields.vatRate / 100);
+                            },
+                            toJSON: false
+                        }
+                    }
+                });
+
+                model = new Model({ netPrice: 100, vatRate: 20});
+                json = model.toJSON({ computedFields: true });
+            });
+
+            it ('should computed field be part of JSON', function () {
+                expect(json.grossPrice).to.be.ok;
             });
 
         });


### PR DESCRIPTION
Addresses #17 by sliceing off any extra arguments and passes them to the original `toJSON` function.  

Also inspects those options to see if `computedFields` was set.  If so, short-circuits the `_.reduce` so the `toJSON: false` option will be ignored.

If this looks good, then I can update the README and even add a test case before you merge it.  The tests pass now, but there's no case for the new option.
