### PR TITLE
Don't include depends functions in the fields hash.

### DIFF
--- a/src/backbone.computedfields.js
+++ b/src/backbone.computedfields.js
@@ -121,7 +121,9 @@ Backbone.ComputedFields = (function(Backbone, _){
 
         _dependentFields: function (depends) {
             return _.reduce(depends, function (memo, field) {
-                memo[field] = this.model.get(field);
+                if (_.isString(field)) {
+                    memo[field] = this.model.get(field);
+                }
                 return memo;
             }, {}, this);
         }

--- a/test/spec/backbone.computedfields.spec.js
+++ b/test/spec/backbone.computedfields.spec.js
@@ -647,6 +647,15 @@ describe('Backbone.ComputedFields spec', function() {
                 expect(model.get('grossPrice')).to.equal(1);
             });
         });
+        
+        it ('should not pass the depends function as a field', function() {
+            var computedDef = model.computed.grossPrice;
+            var dependsFunction = computedDef.depends[2];
+
+            sinon.spy(computedDef, 'get');
+            model.set('netPrice', '100');
+            expect(computedDef.get.firstCall.args[0]).to.not.contain.key(dependsFunction.toString());
+        });
 
     });
 


### PR DESCRIPTION
I noticed that when a computed field has a depends function the fields hash will have a key for the toString value of the depends function.